### PR TITLE
Minor changes to ArdOSC 

### DIFF
--- a/OSCDecoder.cpp
+++ b/OSCDecoder.cpp
@@ -20,7 +20,7 @@
 #include "OSCcommon/OSCArg.h"
 
 
-int16_t OSCDecoder::decode( OSCMessage::OSCMessage *_newMes , const uint8_t *_binData ){
+int16_t OSCDecoder::decode( OSCMessage *_newMes , const uint8_t *_binData ){
 	
 	
 	const uint8_t *packStartPtr = _binData;

--- a/OSCEncoder.cpp
+++ b/OSCEncoder.cpp
@@ -20,7 +20,7 @@
 #include "OSCCommon/OSCArg.h"
 
 
-int16_t OSCEncoder::encode( OSCMessage::OSCMessage *_newMes ,uint8_t *_binData ){
+int16_t OSCEncoder::encode( OSCMessage *_newMes ,uint8_t *_binData ){
 	
 	uint8_t *packStartPtr = _binData;
     	
@@ -40,7 +40,7 @@ int16_t OSCEncoder::encode( OSCMessage::OSCMessage *_newMes ,uint8_t *_binData )
 	packStartPtr += _newMes->_typeTagAlignmentSize;
 	
 	
-//=========== Auguments -> BIN Encode   ==================
+//=========== Arguments -> BIN Encode   ==================
 	
 
 	for ( uint8_t i=0 ; i < _newMes->_argsNum ; i++ ) {

--- a/OSCMessage.cpp
+++ b/OSCMessage.cpp
@@ -1,8 +1,7 @@
 /*
  
  ArdOSC 2.1 - OSC Library for Arduino.
- 
- -------- Lisence -----------------------------------------------------------
+ -------- License -----------------------------------------------------------
  
  ArdOSC
  
@@ -170,12 +169,9 @@ int16_t OSCMessage::setArgData(char _type , void *_value , uint8_t _byte,bool _e
     return alignSize;
 }
 
-
-
-
 int16_t OSCMessage::addArgInt32(int32_t _value){
     
-    if( _argsNum > kMaxAugument ) return -1;
+    if( _argsNum > kMaxArgument ) return -1;
     
     uint8_t tmpValue[4];
     uint8_t *data = (uint8_t*)&_value;
@@ -184,7 +180,6 @@ int16_t OSCMessage::addArgInt32(int32_t _value){
     setArgData( kTagInt32 , tmpValue , 4 , false );
     
     return 1;
-
 }
 
 int32_t OSCMessage::getArgInt32(int16_t _index){
@@ -205,7 +200,7 @@ int32_t OSCMessage::getArgInt32(int16_t _index){
 
 int16_t OSCMessage::addArgFloat(float _value){
     
-    if( _argsNum > kMaxAugument ) return -1;
+    if( _argsNum > kMaxArgument ) return -1;
     
     uint8_t tmpValue[4];
     uint8_t *data = (uint8_t*)&_value;
@@ -235,7 +230,7 @@ float OSCMessage::getArgFloat(int16_t _index){
 #ifdef _USE_STRING_
 int16_t OSCMessage::addArgString(const char* _value){
     
-    if (_argsNum > kMaxAugument ) return -1;
+    if (_argsNum > kMaxArgument ) return -1;
     
     setArgData( kTagString , (void*)_value , strlen(_value) , true );
         

--- a/OSCcommon/OSCClient.h
+++ b/OSCcommon/OSCClient.h
@@ -33,7 +33,7 @@ private:
 
     uint8_t *_sendData;
     
-    OSCEncoder::OSCEncoder encoder;
+    OSCEncoder encoder;
 
     int16_t sockOpen(void);
 	void sockClose(void);

--- a/OSCcommon/OSCDecoder.h
+++ b/OSCcommon/OSCDecoder.h
@@ -23,7 +23,7 @@ class OSCDecoder{
 private:
 
     
-	int16_t decode( OSCMessage::OSCMessage *_mes ,const uint8_t *_binData );
+	int16_t decode( OSCMessage *_mes ,const uint8_t *_binData );
     
 public:
     

--- a/OSCcommon/OSCEncoder.h
+++ b/OSCcommon/OSCEncoder.h
@@ -24,7 +24,7 @@ class OSCEncoder{
 	
 private:
 	
-    int16_t encode( OSCMessage::OSCMessage *mes ,uint8_t *_binData );
+    int16_t encode( OSCMessage *mes ,uint8_t *_binData );
 	
     
 public:

--- a/OSCcommon/OSCMessage.h
+++ b/OSCcommon/OSCMessage.h
@@ -34,9 +34,12 @@
 #define kTagFalse   'F'
 
 
-
-
-
+#ifdef _USE_BLOB_
+struct OSCBlob {
+    uint32_t		len;
+    const uint8_t	*data;			// points into raw message
+};
+#endif
 
 class OSCMessage{
 	
@@ -49,15 +52,13 @@ private:
 	uint16_t	_oscAdrSize;
 	uint16_t	_oscAdrAlignmentSize;
     
-    
 	uint16_t	_typeTagAlignmentSize;
     uint16_t	_argsAlignmentSize;
 	
 	uint16_t	_argsNum;
 
-    OSCArg *    _args[kMaxAugument];
+    OSCArg *    _args[kMaxArgument];
 
- 
     uint16_t getMessageSize(void);
     uint16_t getArgAlignmentSize(uint8_t _index);
   
@@ -104,10 +105,13 @@ public:
     int16_t addArgString(const char* _value);
     int16_t getArgString(int16_t _index, char *_rcvstr);
     int16_t getArgStringSize(int16_t _index);
-
 #endif
 
-    
+#ifdef _USE_BLOB_
+    OSCBlob *getArgBlob(uint16_t _index) {
+        return (OSCBlob *) _args[_index];
+    };
+#endif
 	
 	friend class OSCServer;
 	friend class OSCClient;

--- a/OSCcommon/OSCServer.h
+++ b/OSCcommon/OSCServer.h
@@ -28,8 +28,8 @@ private:
 	uint8_t _rcvData[kMaxRecieveData];
 	
 
-    OSCDecoder::OSCDecoder _decoder;
-    Pattern::Pattern _adrMatch;
+    OSCDecoder _decoder;
+    Pattern _adrMatch;
 	
    
 	void rcvFlush(void);
@@ -44,9 +44,7 @@ public:
 	int16_t begin(uint16_t _recievePort);
 	void stop(void);
 	
-	
     int16_t aviableCheck(void);
-
 
     //_adr osc address string pointer - "/ard/aaa"
     //_func callback function pointer

--- a/OSCcommon/OSCcommon.h
+++ b/OSCcommon/OSCcommon.h
@@ -21,7 +21,7 @@ extern "C" {
 #include <inttypes.h>
 }
 
-#define kMaxAugument	16
+#define kMaxArgument	16
 #define kMaxRecieveData	100
 #define kMaxOSCAdrCharactor	255
 
@@ -34,6 +34,7 @@ extern "C" {
 
 #define _USE_STRING_
 
+#define _USE_BLOB_
 
 //======== user define  end  ========
 


### PR DESCRIPTION
Hello!

 I've been using ArdOSC for a while, and I just patched your latest version to get it to compile with the latest Arduino tool chain (and chipKIT32). 

It wasn't compiling due to places where a return type of (for example) OSCMessage \* was being referred to as OSCMessage::OSCMessage, which is an error since Classname::Classname refers to the constructor for Classname.

Here's the commit message:
Removed Classname::Classname when referencing Classname errors, corrected some spelling errors, added BLOB support (on decode only currently)

Thanks for your good work,
-Scott
